### PR TITLE
 version bump pihole to: 2024.07.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "2024.06.0"
-  VERSION: "2024.06.0"
+  BASE_VERSION: "2024.07.0"
+  VERSION: "2024.07.0"
 
 # Build Stages
 stages:


### PR DESCRIPTION
the developers of pihole have now updated the docker image to 2024.07.0. (still based on pihole version 5)

Changelog: https://github.com/pi-hole/docker-pi-hole/releases/tag/2024.07.0