### PR TITLE
fix: container not running (on: Beta Branch)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
 COPY 99-edns.conf /etc/dnsmasq.d/99-edns.conf
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+RUN chmod +x /docker-entrypoint.sh
+
 ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]


### PR DESCRIPTION
This fixes the issue where execution rights for the file `/docker-entrypoint.sh` are missing when building the container.