### PR TITLE
switch docker beta base tag to development

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "development-v6"
-  VERSION: "development-v6"
+  BASE_VERSION: "development"
+  VERSION: "development"
 
 # Build Stages
 stages:


### PR DESCRIPTION
change the tag of pihole v6 development as it has changed. the latest development of v6 builds are now available under the tag `development`.

See: https://discourse.pi-hole.net/t/thank-you-for-being-part-of-the-v6-beta/72113
> Docker: Switch to the development tag