### PR TITLE
version bump pihole to: 2025.02.1 and more changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "development-v6"
-  VERSION: "development-v6"
+  BASE_VERSION: "2025.02.1"
+  VERSION: "2025.02.1"
 
 # Build Stages
 stages:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
 COPY 99-edns.conf /etc/dnsmasq.d/99-edns.conf
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## The new pihole v6 version series has now been released.

This pull request sets the tagged version to `2025.02.1`. 
At the same time, this pull request also fixes a bug when running the container because the `tini` package was removed in the upstream container (see commit description). 