### PR TITLE
version bump pihole to: 2025.02.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "2025.02.3"
-  VERSION: "2025.02.3"
+  BASE_VERSION: "2025.02.4"
+  VERSION: "2025.02.4"
 
 # Build Stages
 stages:


### PR DESCRIPTION
This pull request sets the tagged version to `2025.02.4`.

Changes of the base image: 
- https://github.com/pi-hole/FTL/compare/v6.0.1...v6.0.2