### PR TITLE
version bump pihole to: 2025.02.6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "2025.02.4"
-  VERSION: "2025.02.4"
+  BASE_VERSION: "2025.02.6"
+  VERSION: "2025.02.6"
 
 # Build Stages
 stages:


### PR DESCRIPTION
This pull request sets the tagged version to `2025.02.6`.

Changes of the base image: 
- https://github.com/pi-hole/pi-hole/compare/v6.0.3...v6.0.4
- https://github.com/pi-hole/PADD/compare/v3.11.1...v4.0.0