### PR TITLE
version bump pihole to: 2025.02.7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "2025.02.6"
-  VERSION: "2025.02.6"
+  BASE_VERSION: "2025.02.7"
+  VERSION: "2025.02.7"
 
 # Build Stages
 stages:


### PR DESCRIPTION
This pull request sets the tagged version to `2025.02.7`.

Changes of the base image: 
- https://github.com/pi-hole/docker-pi-hole/compare/2025.02.6...2025.02.7
- https://github.com/pi-hole/FTL/compare/v6.0.2...v6.0.3