### PR TITLE
version bump pihole to: 2025.04.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "2025.03.1"
-  VERSION: "2025.03.1"
+  BASE_VERSION: "2025.04.0"
+  VERSION: "2025.04.0"
 
 # Build Stages
 stages:


### PR DESCRIPTION
This pull request sets the tagged version to `2025.04.0`.

Changes of the base image: 
- https://github.com/pi-hole/docker-pi-hole/compare/2025.03.1...2025.04.0