### PR TITLE
version bump pihole to: 2025.06.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "2025.04.0"
-  VERSION: "2025.04.0"
+  BASE_VERSION: "2025.06.2"
+  VERSION: "2025.06.2"
 
 # Build Stages
 stages:


### PR DESCRIPTION
This pull request sets the tagged version to `2025.06.2`.

Changes of the base image: 
- https://github.com/pi-hole/docker-pi-hole/compare/2025.04.0...2025.06.2
- https://github.com/pi-hole/FTL/compare/v6.1...v6.2.3
- https://github.com/pi-hole/web/compare/v6.1...v6.2
- https://github.com/pi-hole/pi-hole/compare/v6.1...v6.1.1